### PR TITLE
ci: bump Node version to 24 to match local npm lockfile format

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Setup Pages


### PR DESCRIPTION
Fix CI failure caused by npm lockfile version mismatch.

CI was using Node 20 (npm ~10.x) while the lockfile was generated with Node 24 (npm 11.x). This caused @swc/helpers@0.5.19 to be missing from the lockfile during npm ci on the Linux CI runner.

Bumps the CI Node version to 24 to match the local dev environment.