### PR TITLE
feat: bilingual legal pages (Impressum / Privacy Policy)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,11 +3,16 @@
   "configurations": [
     {
       "name": "Next.js Dev Server",
-      "type": "chrome",
+      "type": "node",
       "request": "launch",
-      "url": "http://localhost:3000",
-      "webRoot": "${workspaceFolder}",
-      "preLaunchTask": "npm: dev"
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "console": "integratedTerminal",
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "- Local:.*?(https?://\\S+)",
+        "uriFormat": "%s"
+      }
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# Claude Instructions – Adama Soaps
+
+> For full project context, see [.github/copilot-instructions.md](.github/copilot-instructions.md).
+> The sections below are Claude-specific rules that **override or extend** the copilot instructions.
+
+---
+
+## Branch & Deployment Strategy
+
+### Branch Roles
+| Branch | Role |
+|--------|------|
+| `main` | **Development branch** — ongoing work lives here |
+| `production` | **Production branch** — Vercel deploys from this branch |
+
+### Rules
+
+1. **Always target `production` for PRs**, not `main`.
+   - All feature branches must open pull requests against `production`.
+   - `main` is for development work; `production` is what ships.
+
+2. **Never check out a branch with upstream tracking.**
+   - Do NOT use `git checkout --track`, `git push -u`, or `git branch --set-upstream-to`.
+   - Tracking bypasses the PR-based preview flow that Vercel depends on.
+   - Always push branches without tracking and open a PR to trigger Vercel's preview build.
+   - When branching from a remote ref, always pass `--no-track`:
+     ```bash
+     git checkout -b my-feature --no-track origin/production
+     ```
+
+3. **Vercel auto-generates preview links for every PR.**
+   - When creating a pull request, always mention in the PR body that Vercel will automatically deploy a preview link for this branch.
+   - Use this preview link to visually verify the changes before merging.
+   - Example note to include in PRs:
+     ```
+     > A Vercel preview deployment will be automatically generated for this PR.
+     > Please verify the changes at the preview URL before merging.
+     ```
+
+---
+
+## Visual Verification
+
+- **Always use Playwright MCP** for visual verification of UI changes.
+- Use the Vercel preview link (from the PR) as the target URL when running Playwright checks after a PR is opened.
+
+---
+
+## Notes for AI Assistants
+
+Follow all guidelines in `.github/copilot-instructions.md` plus:
+
+- ✅ **DO:** Open PRs against `production`, never `main`
+- ✅ **DO:** Include the Vercel preview note in every PR description
+- ✅ **DO:** Use Playwright MCP to visually verify changes
+- ⚠️ **DON'T:** Use `--track` or `-u` when checking out or pushing branches
+- ⚠️ **DON'T:** Push directly to `production` — always go through a PR
+- ⚠️ **DON'T:** Merge without checking the Vercel preview deployment

--- a/app/[locale]/datenschutz/page.tsx
+++ b/app/[locale]/datenschutz/page.tsx
@@ -1,0 +1,260 @@
+export const metadata = {
+  title: "Datenschutz | Adama",
+  description: "Datenschutzerklärung – Adama GbR",
+};
+
+export default function DatenschutzPage() {
+  return (
+    <main className="min-h-screen px-6 py-20" style={{ backgroundColor: "#29291F" }}>
+      <div className="max-w-2xl mx-auto">
+        <p
+          className="font-body mb-4"
+          style={{
+            fontSize: "12px",
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: "rgb(207, 203, 192)",
+          }}
+        >
+          Legal
+        </p>
+        <h1
+          className="font-title font-bold mb-12"
+          style={{ fontSize: "37px", lineHeight: "1.2em", color: "#FFFFFF" }}
+        >
+          Datenschutzerklärung
+        </h1>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            1. Verantwortliche Stelle
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Verantwortlich für die Datenverarbeitung auf dieser Website ist:<br /><br />
+            Adama GbR<br />
+            Denise Peter &amp; Yoav Manor<br />
+            Holzstr. 11, 2.A<br />
+            80469 München<br />
+            E-Mail:{" "}
+            <a
+              href="mailto:adamasoaps@gmail.com"
+              className="transition-opacity duration-300 hover:opacity-70"
+              style={{
+                color: "#FFFFFF",
+                textDecoration: "underline",
+                textUnderlineOffset: "4px",
+              }}
+            >
+              adamasoaps@gmail.com
+            </a>
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            2. Erhebung und Speicherung personenbezogener Daten
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Diese Website erhebt und speichert keine personenbezogenen Daten über Formulare,
+            Newsletter oder Nutzerkonten. Es werden keine Cookies gesetzt, die personenbezogene
+            Daten speichern.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            3. Server-Logfiles
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Beim Besuch dieser Website werden automatisch technische Zugriffsdaten vom Hosting-Anbieter
+            (Vercel Inc., 340 Pine Street, Suite 701, San Francisco, CA 94104, USA) erfasst.
+            Diese sogenannten Server-Logfiles enthalten u.a.:<br /><br />
+            – Browsertyp und Browserversion<br />
+            – verwendetes Betriebssystem<br />
+            – Referrer URL<br />
+            – Hostname des zugreifenden Rechners<br />
+            – Uhrzeit der Serveranfrage<br />
+            – IP-Adresse<br /><br />
+            Diese Daten sind nicht bestimmten Personen zuordenbar und werden nicht mit anderen
+            Datenquellen zusammengeführt. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO
+            (berechtigtes Interesse am sicheren Betrieb der Website).
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            4. Hosting durch Vercel
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Diese Website wird bei Vercel Inc. gehostet. Vercel verarbeitet technische Daten
+            im Rahmen des Betriebs der Infrastruktur. Weitere Informationen finden Sie in der
+            Datenschutzerklärung von Vercel:{" "}
+            <a
+              href="https://vercel.com/legal/privacy-policy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-opacity duration-300 hover:opacity-70"
+              style={{
+                color: "#FFFFFF",
+                textDecoration: "underline",
+                textUnderlineOffset: "4px",
+              }}
+            >
+              vercel.com/legal/privacy-policy
+            </a>
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            5. Keine Tracking- oder Analysetools
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Diese Website verwendet keine Analyse- oder Trackingdienste wie Google Analytics,
+            Meta Pixel oder ähnliche Tools. Es werden keine Nutzungsprofile erstellt.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            6. Kontakt per E-Mail
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Wenn Sie uns per E-Mail kontaktieren, werden Ihre Angaben inklusive der von Ihnen
+            angegebenen Kontaktdaten zur Bearbeitung Ihrer Anfrage gespeichert. Diese Daten geben
+            wir nicht ohne Ihre Einwilligung weiter. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            7. Ihre Rechte
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Sie haben jederzeit das Recht auf:<br /><br />
+            – Auskunft über Ihre gespeicherten Daten (Art. 15 DSGVO)<br />
+            – Berichtigung unrichtiger Daten (Art. 16 DSGVO)<br />
+            – Löschung Ihrer Daten (Art. 17 DSGVO)<br />
+            – Einschränkung der Verarbeitung (Art. 18 DSGVO)<br />
+            – Datenübertragbarkeit (Art. 20 DSGVO)<br />
+            – Widerspruch gegen die Verarbeitung (Art. 21 DSGVO)<br /><br />
+            Zur Ausübung Ihrer Rechte wenden Sie sich bitte an:{" "}
+            <a
+              href="mailto:adamasoaps@gmail.com"
+              className="transition-opacity duration-300 hover:opacity-70"
+              style={{
+                color: "#FFFFFF",
+                textDecoration: "underline",
+                textUnderlineOffset: "4px",
+              }}
+            >
+              adamasoaps@gmail.com
+            </a>
+            <br /><br />
+            Sie haben zudem das Recht, sich bei der zuständigen Aufsichtsbehörde zu beschweren.
+            In Bayern ist dies das Bayerische Landesamt für Datenschutzaufsicht (BayLDA),
+            Promenade 27, 91522 Ansbach.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            8. Aktualität dieser Erklärung
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Diese Datenschutzerklärung ist aktuell gültig und hat den Stand März 2026.
+            Durch die Weiterentwicklung unserer Website kann eine Anpassung notwendig werden.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/[locale]/datenschutz/page.tsx
+++ b/app/[locale]/datenschutz/page.tsx
@@ -1,104 +1,43 @@
-export const metadata = {
-  title: "Datenschutz | Adama",
-  description: "Datenschutzerklärung – Adama GbR",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return locale === "de"
+    ? { title: "Datenschutz | Adama", description: "Datenschutzerklärung – Adama GbR" }
+    : { title: "Privacy Policy | Adama", description: "Privacy Policy – Adama GbR" };
+}
 
-export default function DatenschutzPage() {
-  return (
-    <main className="min-h-screen px-6 py-20" style={{ backgroundColor: "#29291F" }}>
-      <div className="max-w-2xl mx-auto">
-        <p
-          className="font-body mb-4"
-          style={{
-            fontSize: "12px",
-            textTransform: "uppercase",
-            letterSpacing: "0.1em",
-            color: "rgb(207, 203, 192)",
-          }}
-        >
-          Legal
-        </p>
-        <h1
-          className="font-title font-bold mb-12"
-          style={{ fontSize: "37px", lineHeight: "1.2em", color: "#FFFFFF" }}
-        >
-          Datenschutzerklärung
-        </h1>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            1. Verantwortliche Stelle
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+const content = {
+  de: {
+    eyebrow: "Legal",
+    title: "Datenschutzerklärung",
+    sections: [
+      {
+        heading: "1. Verantwortliche Stelle",
+        body: (
+          <>
             Verantwortlich für die Datenverarbeitung auf dieser Website ist:<br /><br />
             Adama GbR<br />
             Denise Peter &amp; Yoav Manor<br />
             Holzstr. 11, 2.A<br />
             80469 München<br />
             E-Mail:{" "}
-            <a
-              href="mailto:adamasoaps@gmail.com"
-              className="transition-opacity duration-300 hover:opacity-70"
-              style={{
-                color: "#FFFFFF",
-                textDecoration: "underline",
-                textUnderlineOffset: "4px",
-              }}
-            >
+            <a href="mailto:adamasoaps@gmail.com" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
               adamasoaps@gmail.com
             </a>
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            2. Erhebung und Speicherung personenbezogener Daten
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
-            Diese Website erhebt und speichert keine personenbezogenen Daten über Formulare,
-            Newsletter oder Nutzerkonten. Es werden keine Cookies gesetzt, die personenbezogene
-            Daten speichern.
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            3. Server-Logfiles
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+          </>
+        ),
+      },
+      {
+        heading: "2. Erhebung und Speicherung personenbezogener Daten",
+        body: "Diese Website erhebt und speichert keine personenbezogenen Daten über Formulare, Newsletter oder Nutzerkonten. Es werden keine Cookies gesetzt, die personenbezogene Daten speichern.",
+      },
+      {
+        heading: "3. Server-Logfiles",
+        body: (
+          <>
             Beim Besuch dieser Website werden automatisch technische Zugriffsdaten vom Hosting-Anbieter
             (Vercel Inc., 340 Pine Street, Suite 701, San Francisco, CA 94104, USA) erfasst.
             Diese sogenannten Server-Logfiles enthalten u.a.:<br /><br />
@@ -111,103 +50,34 @@ export default function DatenschutzPage() {
             Diese Daten sind nicht bestimmten Personen zuordenbar und werden nicht mit anderen
             Datenquellen zusammengeführt. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO
             (berechtigtes Interesse am sicheren Betrieb der Website).
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            4. Hosting durch Vercel
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+          </>
+        ),
+      },
+      {
+        heading: "4. Hosting durch Vercel",
+        body: (
+          <>
             Diese Website wird bei Vercel Inc. gehostet. Vercel verarbeitet technische Daten
             im Rahmen des Betriebs der Infrastruktur. Weitere Informationen finden Sie in der
             Datenschutzerklärung von Vercel:{" "}
-            <a
-              href="https://vercel.com/legal/privacy-policy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="transition-opacity duration-300 hover:opacity-70"
-              style={{
-                color: "#FFFFFF",
-                textDecoration: "underline",
-                textUnderlineOffset: "4px",
-              }}
-            >
+            <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
               vercel.com/legal/privacy-policy
             </a>
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            5. Keine Tracking- oder Analysetools
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
-            Diese Website verwendet keine Analyse- oder Trackingdienste wie Google Analytics,
-            Meta Pixel oder ähnliche Tools. Es werden keine Nutzungsprofile erstellt.
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            6. Kontakt per E-Mail
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
-            Wenn Sie uns per E-Mail kontaktieren, werden Ihre Angaben inklusive der von Ihnen
-            angegebenen Kontaktdaten zur Bearbeitung Ihrer Anfrage gespeichert. Diese Daten geben
-            wir nicht ohne Ihre Einwilligung weiter. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO.
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            7. Ihre Rechte
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+          </>
+        ),
+      },
+      {
+        heading: "5. Keine Tracking- oder Analysetools",
+        body: "Diese Website verwendet keine Analyse- oder Trackingdienste wie Google Analytics, Meta Pixel oder ähnliche Tools. Es werden keine Nutzungsprofile erstellt.",
+      },
+      {
+        heading: "6. Kontakt per E-Mail",
+        body: "Wenn Sie uns per E-Mail kontaktieren, werden Ihre Angaben inklusive der von Ihnen angegebenen Kontaktdaten zur Bearbeitung Ihrer Anfrage gespeichert. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO.",
+      },
+      {
+        heading: "7. Ihre Rechte",
+        body: (
+          <>
             Sie haben jederzeit das Recht auf:<br /><br />
             – Auskunft über Ihre gespeicherten Daten (Art. 15 DSGVO)<br />
             – Berichtigung unrichtiger Daten (Art. 16 DSGVO)<br />
@@ -216,44 +86,154 @@ export default function DatenschutzPage() {
             – Datenübertragbarkeit (Art. 20 DSGVO)<br />
             – Widerspruch gegen die Verarbeitung (Art. 21 DSGVO)<br /><br />
             Zur Ausübung Ihrer Rechte wenden Sie sich bitte an:{" "}
-            <a
-              href="mailto:adamasoaps@gmail.com"
-              className="transition-opacity duration-300 hover:opacity-70"
-              style={{
-                color: "#FFFFFF",
-                textDecoration: "underline",
-                textUnderlineOffset: "4px",
-              }}
-            >
+            <a href="mailto:adamasoaps@gmail.com" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
               adamasoaps@gmail.com
             </a>
             <br /><br />
             Sie haben zudem das Recht, sich bei der zuständigen Aufsichtsbehörde zu beschweren.
             In Bayern ist dies das Bayerische Landesamt für Datenschutzaufsicht (BayLDA),
             Promenade 27, 91522 Ansbach.
-          </p>
-        </section>
+          </>
+        ),
+      },
+      {
+        heading: "8. Aktualität dieser Erklärung",
+        body: "Diese Datenschutzerklärung ist aktuell gültig und hat den Stand März 2026. Durch die Weiterentwicklung unserer Website kann eine Anpassung notwendig werden.",
+      },
+    ],
+  },
+  en: {
+    eyebrow: "Legal",
+    title: "Privacy Policy",
+    sections: [
+      {
+        heading: "1. Data Controller",
+        body: (
+          <>
+            The controller responsible for data processing on this website is:<br /><br />
+            Adama GbR<br />
+            Denise Peter &amp; Yoav Manor<br />
+            Holzstr. 11, 2.A<br />
+            80469 Munich, Germany<br />
+            Email:{" "}
+            <a href="mailto:adamasoaps@gmail.com" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
+              adamasoaps@gmail.com
+            </a>
+          </>
+        ),
+      },
+      {
+        heading: "2. Collection and storage of personal data",
+        body: "This website does not collect or store personal data via forms, newsletters or user accounts. No cookies are set that store personal data.",
+      },
+      {
+        heading: "3. Server log files",
+        body: (
+          <>
+            When you visit this website, technical access data is automatically recorded by our hosting provider
+            (Vercel Inc., 340 Pine Street, Suite 701, San Francisco, CA 94104, USA).
+            These server log files contain, among other things:<br /><br />
+            – Browser type and version<br />
+            – Operating system used<br />
+            – Referrer URL<br />
+            – Hostname of the accessing device<br />
+            – Time of the server request<br />
+            – IP address<br /><br />
+            This data cannot be attributed to specific individuals and is not merged with other data sources.
+            The legal basis is Art. 6 para. 1 lit. f GDPR (legitimate interest in the secure operation of the website).
+          </>
+        ),
+      },
+      {
+        heading: "4. Hosting by Vercel",
+        body: (
+          <>
+            This website is hosted by Vercel Inc. Vercel processes technical data as part of infrastructure operations.
+            For more information, please refer to Vercel&apos;s privacy policy:{" "}
+            <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener noreferrer" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
+              vercel.com/legal/privacy-policy
+            </a>
+          </>
+        ),
+      },
+      {
+        heading: "5. No tracking or analytics tools",
+        body: "This website does not use any analytics or tracking services such as Google Analytics, Meta Pixel or similar tools. No user profiles are created.",
+      },
+      {
+        heading: "6. Contact by email",
+        body: "If you contact us by email, your details including the contact information you provide will be stored for the purpose of processing your enquiry. We will not pass this data on without your consent. The legal basis is Art. 6 para. 1 lit. f GDPR.",
+      },
+      {
+        heading: "7. Your rights",
+        body: (
+          <>
+            You have the right at any time to:<br /><br />
+            – Access your stored data (Art. 15 GDPR)<br />
+            – Rectification of inaccurate data (Art. 16 GDPR)<br />
+            – Erasure of your data (Art. 17 GDPR)<br />
+            – Restriction of processing (Art. 18 GDPR)<br />
+            – Data portability (Art. 20 GDPR)<br />
+            – Object to processing (Art. 21 GDPR)<br /><br />
+            To exercise your rights, please contact:{" "}
+            <a href="mailto:adamasoaps@gmail.com" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
+              adamasoaps@gmail.com
+            </a>
+            <br /><br />
+            You also have the right to lodge a complaint with the competent supervisory authority.
+            In Bavaria, this is the Bavarian State Office for Data Protection Supervision (BayLDA),
+            Promenade 27, 91522 Ansbach, Germany.
+          </>
+        ),
+      },
+      {
+        heading: "8. Currency of this policy",
+        body: "This privacy policy is currently valid and was last updated in March 2026. Updates may be necessary as our website evolves.",
+      },
+    ],
+  },
+};
 
-        <section>
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            8. Aktualität dieser Erklärung
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
-            Diese Datenschutzerklärung ist aktuell gültig und hat den Stand März 2026.
-            Durch die Weiterentwicklung unserer Website kann eine Anpassung notwendig werden.
-          </p>
-        </section>
+export default async function DatenschutzPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const c = locale === "de" ? content.de : content.en;
+
+  return (
+    <main className="min-h-screen px-6 py-20" style={{ backgroundColor: "#29291F" }}>
+      <div className="max-w-2xl mx-auto">
+        <p
+          className="font-body mb-4"
+          style={{ fontSize: "12px", textTransform: "uppercase", letterSpacing: "0.1em", color: "rgb(207, 203, 192)" }}
+        >
+          {c.eyebrow}
+        </p>
+        <h1
+          className="font-title font-bold mb-12"
+          style={{ fontSize: "37px", lineHeight: "1.2em", color: "#FFFFFF" }}
+        >
+          {c.title}
+        </h1>
+
+        {c.sections.map((section, i) => (
+          <section key={i} className={i < c.sections.length - 1 ? "mb-10" : ""}>
+            <h2
+              className="font-body mb-3"
+              style={{ fontSize: "12px", textTransform: "uppercase", letterSpacing: "0.1em", color: "rgb(207, 203, 192)" }}
+            >
+              {section.heading}
+            </h2>
+            <p
+              className="font-body leading-relaxed"
+              style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+            >
+              {section.body}
+            </p>
+          </section>
+        ))}
       </div>
     </main>
   );

--- a/app/[locale]/impressum/page.tsx
+++ b/app/[locale]/impressum/page.tsx
@@ -1,187 +1,175 @@
-export const metadata = {
-  title: "Impressum | Adama",
-  description: "Impressum – Adama GbR",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  return locale === "de"
+    ? { title: "Impressum | Adama", description: "Impressum – Adama GbR" }
+    : { title: "Legal Notice | Adama", description: "Legal Notice – Adama GbR" };
+}
 
-export default function ImpressumPage() {
-  return (
-    <main className="min-h-screen px-6 py-20" style={{ backgroundColor: "#29291F" }}>
-      <div className="max-w-2xl mx-auto">
-        <p
-          className="font-body mb-4"
-          style={{
-            fontSize: "12px",
-            textTransform: "uppercase",
-            letterSpacing: "0.1em",
-            color: "rgb(207, 203, 192)",
-          }}
-        >
-          Legal
-        </p>
-        <h1
-          className="font-title font-bold mb-12"
-          style={{ fontSize: "37px", lineHeight: "1.2em", color: "#FFFFFF" }}
-        >
-          Impressum
-        </h1>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            Angaben gemäß § 5 TMG
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+const content = {
+  de: {
+    eyebrow: "Legal",
+    title: "Impressum",
+    sections: [
+      {
+        heading: "Angaben gemäß § 5 TMG",
+        body: (
+          <>
             Adama GbR<br />
             Denise Peter &amp; Yoav Manor<br />
             Holzstr. 11, 2.A<br />
             80469 München<br />
             Deutschland
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            Kontakt
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+          </>
+        ),
+      },
+      {
+        heading: "Kontakt",
+        body: (
+          <>
             E-Mail:{" "}
-            <a
-              href="mailto:adamasoaps@gmail.com"
-              className="transition-opacity duration-300 hover:opacity-70"
-              style={{
-                color: "#FFFFFF",
-                textDecoration: "underline",
-                textUnderlineOffset: "4px",
-              }}
-            >
+            <a href="mailto:adamasoaps@gmail.com" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
               adamasoaps@gmail.com
             </a>
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            Umsatzsteuer
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
-            Adama GbR ist als Kleinunternehmen gemäß § 19 UStG von der Umsatzsteuer befreit.
-            Es wird daher keine Umsatzsteuer-Identifikationsnummer benötigt.
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            Verantwortlich für den Inhalt (§ 55 Abs. 2 RStV)
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+          </>
+        ),
+      },
+      {
+        heading: "Umsatzsteuer",
+        body: "Adama GbR ist als Kleinunternehmen gemäß § 19 UStG von der Umsatzsteuer befreit. Es wird daher keine Umsatzsteuer-Identifikationsnummer benötigt.",
+      },
+      {
+        heading: "Verantwortlich für den Inhalt (§ 55 Abs. 2 RStV)",
+        body: (
+          <>
             Denise Peter &amp; Yoav Manor<br />
             Holzstr. 11, 2.A<br />
             80469 München
-          </p>
-        </section>
-
-        <section className="mb-10">
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            Streitschlichtung
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
+          </>
+        ),
+      },
+      {
+        heading: "Streitschlichtung",
+        body: (
+          <>
             Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:{" "}
-            <a
-              href="https://ec.europa.eu/consumers/odr"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="transition-opacity duration-300 hover:opacity-70"
-              style={{
-                color: "#FFFFFF",
-                textDecoration: "underline",
-                textUnderlineOffset: "4px",
-              }}
-            >
+            <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
               https://ec.europa.eu/consumers/odr
+            </a>.<br /><br />
+            Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
+          </>
+        ),
+      },
+      {
+        heading: "Haftung für Inhalte",
+        body: "Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.",
+      },
+    ],
+  },
+  en: {
+    eyebrow: "Legal",
+    title: "Legal Notice",
+    sections: [
+      {
+        heading: "Information pursuant to § 5 TMG",
+        body: (
+          <>
+            Adama GbR<br />
+            Denise Peter &amp; Yoav Manor<br />
+            Holzstr. 11, 2.A<br />
+            80469 Munich<br />
+            Germany
+          </>
+        ),
+      },
+      {
+        heading: "Contact",
+        body: (
+          <>
+            Email:{" "}
+            <a href="mailto:adamasoaps@gmail.com" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
+              adamasoaps@gmail.com
             </a>
-            .<br /><br />
-            Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer
-            Verbraucherschlichtungsstelle teilzunehmen.
-          </p>
-        </section>
+          </>
+        ),
+      },
+      {
+        heading: "VAT",
+        body: "Adama GbR is exempt from VAT as a small business pursuant to § 19 UStG. No VAT identification number is therefore required.",
+      },
+      {
+        heading: "Responsible for content (§ 55 para. 2 RStV)",
+        body: (
+          <>
+            Denise Peter &amp; Yoav Manor<br />
+            Holzstr. 11, 2.A<br />
+            80469 Munich
+          </>
+        ),
+      },
+      {
+        heading: "Dispute resolution",
+        body: (
+          <>
+            The European Commission provides a platform for online dispute resolution (ODR):{" "}
+            <a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer" className="transition-opacity duration-300 hover:opacity-70" style={{ color: "#FFFFFF", textDecoration: "underline", textUnderlineOffset: "4px" }}>
+              https://ec.europa.eu/consumers/odr
+            </a>.<br /><br />
+            We are not willing or obliged to participate in dispute resolution proceedings before a consumer arbitration board.
+          </>
+        ),
+      },
+      {
+        heading: "Liability for content",
+        body: "As a service provider, we are responsible for our own content on these pages in accordance with general legislation pursuant to § 7 para. 1 TMG. However, pursuant to §§ 8 to 10 TMG, we are not obliged as a service provider to monitor transmitted or stored third-party information or to investigate circumstances that indicate illegal activity.",
+      },
+    ],
+  },
+};
 
-        <section>
-          <h2
-            className="font-body mb-3"
-            style={{
-              fontSize: "12px",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-              color: "rgb(207, 203, 192)",
-            }}
-          >
-            Haftung für Inhalte
-          </h2>
-          <p
-            className="font-body leading-relaxed"
-            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
-          >
-            Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten
-            nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als
-            Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde
-            Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige
-            Tätigkeit hinweisen.
-          </p>
-        </section>
+export default async function ImpressumPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const c = locale === "de" ? content.de : content.en;
+
+  return (
+    <main className="min-h-screen px-6 py-20" style={{ backgroundColor: "#29291F" }}>
+      <div className="max-w-2xl mx-auto">
+        <p
+          className="font-body mb-4"
+          style={{ fontSize: "12px", textTransform: "uppercase", letterSpacing: "0.1em", color: "rgb(207, 203, 192)" }}
+        >
+          {c.eyebrow}
+        </p>
+        <h1
+          className="font-title font-bold mb-12"
+          style={{ fontSize: "37px", lineHeight: "1.2em", color: "#FFFFFF" }}
+        >
+          {c.title}
+        </h1>
+
+        {c.sections.map((section, i) => (
+          <section key={i} className={i < c.sections.length - 1 ? "mb-10" : ""}>
+            <h2
+              className="font-body mb-3"
+              style={{ fontSize: "12px", textTransform: "uppercase", letterSpacing: "0.1em", color: "rgb(207, 203, 192)" }}
+            >
+              {section.heading}
+            </h2>
+            <p
+              className="font-body leading-relaxed"
+              style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+            >
+              {section.body}
+            </p>
+          </section>
+        ))}
       </div>
     </main>
   );

--- a/app/[locale]/impressum/page.tsx
+++ b/app/[locale]/impressum/page.tsx
@@ -1,0 +1,188 @@
+export const metadata = {
+  title: "Impressum | Adama",
+  description: "Impressum – Adama GbR",
+};
+
+export default function ImpressumPage() {
+  return (
+    <main className="min-h-screen px-6 py-20" style={{ backgroundColor: "#29291F" }}>
+      <div className="max-w-2xl mx-auto">
+        <p
+          className="font-body mb-4"
+          style={{
+            fontSize: "12px",
+            textTransform: "uppercase",
+            letterSpacing: "0.1em",
+            color: "rgb(207, 203, 192)",
+          }}
+        >
+          Legal
+        </p>
+        <h1
+          className="font-title font-bold mb-12"
+          style={{ fontSize: "37px", lineHeight: "1.2em", color: "#FFFFFF" }}
+        >
+          Impressum
+        </h1>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            Angaben gemäß § 5 TMG
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Adama GbR<br />
+            Denise Peter &amp; Yoav Manor<br />
+            Holzstr. 11, 2.A<br />
+            80469 München<br />
+            Deutschland
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            Kontakt
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            E-Mail:{" "}
+            <a
+              href="mailto:adamasoaps@gmail.com"
+              className="transition-opacity duration-300 hover:opacity-70"
+              style={{
+                color: "#FFFFFF",
+                textDecoration: "underline",
+                textUnderlineOffset: "4px",
+              }}
+            >
+              adamasoaps@gmail.com
+            </a>
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            Umsatzsteuer
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Adama GbR ist als Kleinunternehmen gemäß § 19 UStG von der Umsatzsteuer befreit.
+            Es wird daher keine Umsatzsteuer-Identifikationsnummer benötigt.
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            Verantwortlich für den Inhalt (§ 55 Abs. 2 RStV)
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Denise Peter &amp; Yoav Manor<br />
+            Holzstr. 11, 2.A<br />
+            80469 München
+          </p>
+        </section>
+
+        <section className="mb-10">
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            Streitschlichtung
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:{" "}
+            <a
+              href="https://ec.europa.eu/consumers/odr"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-opacity duration-300 hover:opacity-70"
+              style={{
+                color: "#FFFFFF",
+                textDecoration: "underline",
+                textUnderlineOffset: "4px",
+              }}
+            >
+              https://ec.europa.eu/consumers/odr
+            </a>
+            .<br /><br />
+            Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer
+            Verbraucherschlichtungsstelle teilzunehmen.
+          </p>
+        </section>
+
+        <section>
+          <h2
+            className="font-body mb-3"
+            style={{
+              fontSize: "12px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "rgb(207, 203, 192)",
+            }}
+          >
+            Haftung für Inhalte
+          </h2>
+          <p
+            className="font-body leading-relaxed"
+            style={{ fontSize: "15px", color: "rgb(207, 203, 192)" }}
+          >
+            Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten
+            nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als
+            Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde
+            Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige
+            Tätigkeit hinweisen.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -86,8 +86,8 @@ export default function Footer() {
             </div>
           </div>
 
-          {/* Links */}
-          {/* <div>
+          {/* Legal */}
+          <div>
             <h4
               className="font-heading font-normal mb-4"
               style={{
@@ -97,66 +97,33 @@ export default function Footer() {
                 fontWeight: "600",
               }}
             >
-              Policies
+              Legal
             </h4>
             <div className="space-y-2">
               <Link
-                href="/policies/privacy"
+                href="/impressum"
                 className="block font-body transition-opacity duration-300 hover:opacity-70"
                 style={{
                   fontSize: "15px",
                   lineHeight: "24px",
-                  color: "rgb(255, 255, 255)",
+                  color: "rgb(207, 203, 192)",
                 }}
               >
-                Privacy Policy
+                Impressum
               </Link>
               <Link
-                href="/policies/accessibility"
+                href="/datenschutz"
                 className="block font-body transition-opacity duration-300 hover:opacity-70"
                 style={{
                   fontSize: "15px",
                   lineHeight: "24px",
-                  color: "rgb(255, 255, 255)",
+                  color: "rgb(207, 203, 192)",
                 }}
               >
-                Accessibility Statement
-              </Link>
-              <Link
-                href="/policies/shipping"
-                className="block font-body transition-opacity duration-300 hover:opacity-70"
-                style={{
-                  fontSize: "15px",
-                  lineHeight: "24px",
-                  color: "rgb(255, 255, 255)",
-                }}
-              >
-                Shipping Policy
-              </Link>
-              <Link
-                href="/policies/terms"
-                className="block font-body transition-opacity duration-300 hover:opacity-70"
-                style={{
-                  fontSize: "15px",
-                  lineHeight: "24px",
-                  color: "rgb(255, 255, 255)",
-                }}
-              >
-                Terms & Conditions
-              </Link>
-              <Link
-                href="/policies/returns"
-                className="block font-body transition-opacity duration-300 hover:opacity-70"
-                style={{
-                  fontSize: "15px",
-                  lineHeight: "24px",
-                  color: "rgb(255, 255, 255)",
-                }}
-              >
-                Refund Policy
+                Datenschutz
               </Link>
             </div>
-          </div> */}
+          </div>
         </div>
 
         {/* Newsletter Section */}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 
 export default function Footer() {
   const t = useTranslations("footer");
+  const locale = useLocale();
 
   return (
     <footer
@@ -97,11 +98,11 @@ export default function Footer() {
                 fontWeight: "600",
               }}
             >
-              Legal
+              {t("legal")}
             </h4>
             <div className="space-y-2">
               <Link
-                href="/impressum"
+                href={`/${locale}/impressum`}
                 className="block font-body transition-opacity duration-300 hover:opacity-70"
                 style={{
                   fontSize: "15px",
@@ -109,10 +110,10 @@ export default function Footer() {
                   color: "rgb(207, 203, 192)",
                 }}
               >
-                Impressum
+                {t("legalNotice")}
               </Link>
               <Link
-                href="/datenschutz"
+                href={`/${locale}/datenschutz`}
                 className="block font-body transition-opacity duration-300 hover:opacity-70"
                 style={{
                   fontSize: "15px",
@@ -120,7 +121,7 @@ export default function Footer() {
                   color: "rgb(207, 203, 192)",
                 }}
               >
-                Datenschutz
+                {t("privacyPolicy")}
               </Link>
             </div>
           </div>

--- a/messages/de.json
+++ b/messages/de.json
@@ -111,8 +111,10 @@
   "footer": {
     "brandName": "Adama Soaps",
     "contact": "Kontakt",
+    "legal": "Legal",
+    "legalNotice": "Impressum",
+    "privacyPolicy": "Datenschutz",
     "policies": "Richtlinien",
-    "privacyPolicy": "Datenschutzrichtlinie",
     "accessibilityStatement": "Barrierefreiheitserklärung",
     "shippingPolicy": "Versandrichtlinie",
     "termsConditions": "AGB",

--- a/messages/en.json
+++ b/messages/en.json
@@ -111,8 +111,10 @@
   "footer": {
     "brandName": "Adama Soaps",
     "contact": "Contact",
-    "policies": "Policies",
+    "legal": "Legal",
+    "legalNotice": "Legal Notice",
     "privacyPolicy": "Privacy Policy",
+    "policies": "Policies",
     "accessibilityStatement": "Accessibility Statement",
     "shippingPolicy": "Shipping Policy",
     "termsConditions": "Terms & Conditions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1603,6 +1604,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2129,6 +2131,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2188,6 +2191,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -2687,6 +2691,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2973,6 +2978,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -3036,6 +3042,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3609,6 +3616,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3794,6 +3802,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4171,6 +4180,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6130,6 +6140,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6139,6 +6150,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6827,6 +6839,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6988,6 +7001,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7277,6 +7291,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- Impressum (DE) / Legal Notice (EN) and Datenschutz (DE) / Privacy Policy (EN) now render in the correct language based on active locale
- Footer links use locale-prefixed paths via `useLocale()` — fixes 404s
- Footer labels translated via next-intl (`legalNotice`, `privacyPolicy` keys added to both `en.json` and `de.json`)
- Fixes pre-existing build failure caused by missing `@playwright/test` dev dependency
- Adds `CLAUDE.md` with branch/deployment workflow rules
- Adds `.vscode/launch.json` for F5 dev server launch

## Test plan

- [ ] Visit `/de/impressum` — renders in German
- [ ] Visit `/en/impressum` — renders in English ("Legal Notice")
- [ ] Visit `/de/datenschutz` — renders in German
- [ ] Visit `/en/datenschutz` — renders in English ("Privacy Policy")
- [ ] Footer on DE site: links show "Impressum" / "Datenschutz" and navigate correctly
- [ ] Footer on EN site: links show "Legal Notice" / "Privacy Policy" and navigate correctly

> A Vercel preview deployment will be automatically generated for this PR.
> Please verify the changes at the preview URL before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)