### PR TITLE
fix: remove Legal heading from footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -89,17 +89,6 @@ export default function Footer() {
 
           {/* Legal */}
           <div>
-            <h4
-              className="font-heading font-normal mb-4"
-              style={{
-                fontSize: "17px",
-                lineHeight: "1.5em",
-                color: "rgb(255, 255, 255)",
-                fontWeight: "600",
-              }}
-            >
-              {t("legal")}
-            </h4>
             <div className="space-y-2">
               <Link
                 href={`/${locale}/impressum`}


### PR DESCRIPTION
Removes the "Legal" section heading from the footer, leaving the Impressum/Legal Notice and Datenschutz/Privacy Policy links without a heading above them — applies to both English and German versions.

> A Vercel preview deployment will be automatically generated for this PR.
> Please verify the changes at the preview URL before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)