### PR TITLE
feat: add comprehensive SEO schema markup

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -4,9 +4,106 @@ import OurStory from "@/components/OurStory";
 import CafePartners from "@/components/CafePartners";
 import FollowUs from "@/components/FollowUs";
 
-export default function Home() {
+const BASE_URL = "https://adamasoaps.com";
+
+function getHomepageSchemas(locale: string) {
+  const isDE = locale === "de";
+  const description = isDE
+    ? "Handgemachte kaltgerührte Seife aus recyceltem Kaffeesatz von Münchner Cafés. Vegan, nachhaltig, plastikfrei."
+    : "Handmade cold-process soap made with recycled coffee grounds from Munich cafés. Vegan, sustainable, plastic-free.";
+
+  const organization = {
+    "@context": "https://schema.org",
+    "@type": ["Organization", "Brand"],
+    "@id": `${BASE_URL}/#organization`,
+    name: "Adama Soaps",
+    url: BASE_URL,
+    logo: {
+      "@type": "ImageObject",
+      "@id": `${BASE_URL}/#logo`,
+      url: `${BASE_URL}/logo-black.svg`,
+      contentUrl: `${BASE_URL}/logo-black.svg`,
+    },
+    description,
+    email: "Adamasoaps@gmail.com",
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "Holzstr. 11 2/a",
+      addressLocality: "Munich",
+      postalCode: "80469",
+      addressCountry: "DE",
+    },
+    sameAs: ["https://instagram.com/adamasoaps"],
+  };
+
+  const localBusiness = {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "@id": `${BASE_URL}/#localbusiness`,
+    name: "Adama Soaps",
+    description,
+    url: BASE_URL,
+    email: "Adamasoaps@gmail.com",
+    image: `${BASE_URL}/logo-black.svg`,
+    logo: `${BASE_URL}/logo-black.svg`,
+    priceRange: "€€",
+    currenciesAccepted: "EUR",
+    paymentAccepted: "PayPal",
+    address: {
+      "@type": "PostalAddress",
+      streetAddress: "Holzstr. 11 2/a",
+      addressLocality: "Munich",
+      postalCode: "80469",
+      addressCountry: "DE",
+    },
+    geo: {
+      "@type": "GeoCoordinates",
+      latitude: 48.132,
+      longitude: 11.566,
+    },
+    areaServed: { "@type": "Country", name: "Germany" },
+    sameAs: ["https://instagram.com/adamasoaps"],
+  };
+
+  const website = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": `${BASE_URL}/#website`,
+    url: BASE_URL,
+    name: "Adama Soaps",
+    description,
+    publisher: { "@id": `${BASE_URL}/#organization` },
+    inLanguage: isDE ? "de-DE" : "en-US",
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${BASE_URL}/${locale}/shop?q={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+
+  return [organization, localBusiness, website];
+}
+
+export default async function Home({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const schemas = getHomepageSchemas(locale);
+
   return (
     <>
+      {schemas.map((schema, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+        />
+      ))}
       <DiscoverSoaps />
       <HeroSection />
       <CafePartners />

--- a/app/[locale]/shop/[slug]/page.tsx
+++ b/app/[locale]/shop/[slug]/page.tsx
@@ -46,34 +46,44 @@ export async function generateMetadata({
   };
 }
 
-function getProductJsonLd(product: (typeof products)[number], locale: string) {
-  const baseUrl = "https://adama-soaps.com";
+function getProductSchemas(product: (typeof products)[number], locale: string) {
+  const baseUrl = "https://adamasoaps.com";
   const productUrl = `${baseUrl}/${locale}/shop/${product.slug}/`;
   const isDE = locale === "de";
 
-  return {
+  const productSchema = {
     "@context": "https://schema.org",
     "@type": "Product",
+    "@id": `${productUrl}#product`,
     name: product.name,
-    description: product.description.split("\n")[0],
+    description: product.description.replace(/\n+/g, " ").trim(),
     image: product.images.map((img) =>
       img.startsWith("http") ? img : `${baseUrl}${img}`,
     ),
     brand: {
       "@type": "Brand",
       name: "Adama Soaps",
+      "@id": `${baseUrl}/#organization`,
     },
     url: productUrl,
     sku: product.id,
     category: isDE ? "Handgemachte Seife" : "Handmade Soap",
     material: isDE ? "Natürliche Inhaltsstoffe" : "Natural Ingredients",
+    keywords: isDE
+      ? `${product.name}, handgemachte Seife, Kaffeeseife, vegane Seife, München, nachhaltig, plastikfrei`
+      : `${product.name}, handmade soap, coffee soap, vegan soap, Munich, sustainable, plastic-free`,
     ...(product.ingredients && {
-      additionalProperty: {
+      additionalProperty: product.ingredients.map((ingredient) => ({
         "@type": "PropertyValue",
-        name: "Ingredients",
-        value: product.ingredients.join(", "),
-      },
+        name: isDE ? "Zutat" : "Ingredient",
+        value: ingredient,
+      })),
     }),
+    manufacturer: {
+      "@type": "Organization",
+      name: "Adama Soaps",
+      "@id": `${baseUrl}/#organization`,
+    },
     offers: {
       "@type": "Offer",
       url: productUrl,
@@ -94,6 +104,7 @@ function getProductJsonLd(product: (typeof products)[number], locale: string) {
       seller: {
         "@type": "Organization",
         name: "Adama Soaps",
+        "@id": `${baseUrl}/#organization`,
       },
       shippingDetails: {
         "@type": "OfferShippingDetails",
@@ -104,6 +115,33 @@ function getProductJsonLd(product: (typeof products)[number], locale: string) {
       },
     },
   };
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: isDE ? "Startseite" : "Home",
+        item: `${baseUrl}/${locale}/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Shop",
+        item: `${baseUrl}/${locale}/shop/`,
+      },
+      {
+        "@type": "ListItem",
+        position: 3,
+        name: product.name,
+        item: productUrl,
+      },
+    ],
+  };
+
+  return [productSchema, breadcrumbSchema];
 }
 
 export default async function ProductPage({
@@ -122,14 +160,17 @@ export default async function ProductPage({
     notFound();
   }
 
-  const jsonLd = getProductJsonLd(product, locale);
+  const schemas = getProductSchemas(product, locale);
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+      {schemas.map((schema, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+        />
+      ))}
       <ProductDetails product={product} />
     </>
   );

--- a/app/[locale]/shop/layout.tsx
+++ b/app/[locale]/shop/layout.tsx
@@ -1,4 +1,5 @@
 import { getMessages } from "next-intl/server";
+import { products } from "@/data/products";
 
 export async function generateMetadata({
   params,
@@ -16,10 +17,71 @@ export async function generateMetadata({
   };
 }
 
-export default function ShopLayout({
+function getShopSchema(locale: string) {
+  const baseUrl = "https://adamasoaps.com";
+  const isDE = locale === "de";
+  const shopUrl = `${baseUrl}/${locale}/shop/`;
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${shopUrl}#page`,
+    name: isDE
+      ? "Handgemachte Vegane Kaffeeseifen"
+      : "Handmade Vegan Coffee Soaps",
+    description: isDE
+      ? "Entdecke unsere Kollektion handgemachter veganer Kaffeeseifen aus recyceltem Kaffeesatz von Münchner Cafés."
+      : "Browse our collection of handmade vegan coffee soaps made with recycled coffee grounds from Munich cafés.",
+    url: shopUrl,
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: isDE ? "Startseite" : "Home",
+          item: `${baseUrl}/${locale}/`,
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Shop",
+          item: shopUrl,
+        },
+      ],
+    },
+    mainEntity: {
+      "@type": "ItemList",
+      name: isDE
+        ? "Handgemachte Vegane Kaffeeseifen"
+        : "Handmade Vegan Coffee Soaps",
+      itemListElement: products.map((product, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: `${baseUrl}/${locale}/shop/${product.slug}/`,
+        name: product.name,
+      })),
+    },
+  };
+}
+
+export default async function ShopLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: Promise<{ locale: string }>;
 }) {
-  return children;
+  const { locale } = await params;
+  const schema = getShopSchema(locale);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary

- **Homepage** — adds `Organization`, `LocalBusiness`, and `WebSite` JSON-LD schemas with address (Holzstr. 11 2/a, Munich), geo coordinates, contact email, Instagram `sameAs`, and a `SearchAction` potentialAction
- **Product pages** — enhances existing `Product` schema (full description, each ingredient as `additionalProperty`, `keywords`, `manufacturer`) and adds a `BreadcrumbList` schema (Home → Shop → Product); also fixes wrong domain (`adama-soaps.com` → `adamasoaps.com`)
- **Shop page** — adds `CollectionPage` + `ItemList` schema with an embedded breadcrumb
- All schemas are locale-aware (EN/DE)

Zero visual changes — purely invisible `<script type="application/ld+json">` tags in the HTML.

## What this unlocks in Google Search
- Rich snippets: price + availability next to product results
- Business Knowledge Panel with address & contact info
- Breadcrumb trails shown in search results
- Better site structure understanding for the product catalogue

## Test plan
- [ ] Verify build passes (already confirmed locally ✓)
- [ ] Check schema on homepage with [Google Rich Results Test](https://search.google.com/test/rich-results)
- [ ] Check schema on a product page (e.g. `/en/shop/calm`)
- [ ] Check schema on `/en/shop`
- [ ] Validate no visual regressions at the Vercel preview URL

> A Vercel preview deployment will be automatically generated for this PR.
> Please verify the changes at the preview URL before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)