### PR TITLE
Rename Adama Easter Set to Adama Bundle, reorder carousel

### DIFF
--- a/data/paypal-buttons.ts
+++ b/data/paypal-buttons.ts
@@ -4,7 +4,7 @@
 export const paypalAddToCartButtons: Record<string, string> = {
   calm: "SCTN97A48MV5L",
   "sunny-sage": "997RRPSCH8KG4",
-  "adama-easter-set": "N7YLSV2NMZ3D8",
+  "adama-bundle": "N7YLSV2NMZ3D8",
 };
 
 export function getPayPalAddToCartButtonId(

--- a/data/products.ts
+++ b/data/products.ts
@@ -29,20 +29,6 @@ export const products: Product[] = [
     ],
   },
   {
-    id: "3",
-    name: "Adama Easter Set",
-    slug: "adama-easter-set",
-    price: 19.99,
-    ribbon: "Special Offer",
-    images: [
-      withBasePath("/images/products/EasterSet/EasterSet-1.png"),
-      withBasePath("/images/products/EasterSet/EasterSet-2.png"),
-    ],
-    description:
-      "This Easter, give a gift that actually means something.\n\nThe Adama Easter Set brings together two of our handmade soaps — Sunny Sage and Calm — alongside a handcrafted wooden soap tray, made to keep your bar dry and your bathroom beautiful.\n\nEvery soap is cold-processed by hand in Munich, made from recycled coffee grounds sourced from local cafés. No plastic. No waste. Just something real.\n\nWhat's inside:\n— 1 × Sunny Sage soap (100g)\n— 1 × Calm soap (100g)\n— 1 × Handmade wooden soap tray\n\nFor the full ingredients list, visit the individual product pages for Sunny Sage and Calm.",
-    inStock: true,
-  },
-  {
     id: "2",
     name: "Sunny Sage",
     slug: "sunny-sage",
@@ -70,5 +56,19 @@ export const products: Product[] = [
       "Geraniol",
       "Citral",
     ],
+  },
+  {
+    id: "3",
+    name: "Adama Bundle",
+    slug: "adama-bundle",
+    price: 19.99,
+    ribbon: "Special Offer",
+    images: [
+      withBasePath("/images/products/EasterSet/EasterSet-1.png"),
+      withBasePath("/images/products/EasterSet/EasterSet-2.png"),
+    ],
+    description:
+      "Two bars. One tray. The whole ritual.\n\nThe Adama Bundle pairs both of our handmade coffee-scrub bars - Sunny Sage (orange + sage) and Calm (lavender) with a handcrafted wooden soap tray made to keep them dry between showers.\n\nBoth bars are cold-processed by hand here in Munich, made with coffee grounds we upcycle from local cafés. Vegan. Plastic-free. Nothing in here we wouldn't put on our own skin.\n\nFor yourself. Or for someone you'd give something real to.\n\nWhat's inside:\n- 1 × Sunny Sage soap (100g)\n- 1 × Calm soap (100g)\n- 1 × Handmade wooden soap tray\n\nFor the full ingredient lists, see the Sunny Sage and Calm product pages.\n\nAdama. Stay clean. Stay grounded.",
+    inStock: true,
   },
 ];

--- a/messages/de.json
+++ b/messages/de.json
@@ -73,9 +73,9 @@
         "Limonene"
       ]
     },
-    "adama-easter-set": {
-      "name": "Adama Oster-Set",
-      "description": "Dieses Ostern, schenke etwas, das wirklich bedeutet.\n\nDas Adama Oster-Set vereint zwei unserer handgemachten Seifen — Sunny Sage und Calm — zusammen mit einem handgefertigten Holzseifenhalter, der deine Seife trocken und dein Badezimmer schön hält.\n\nJede Seife wird von Hand kalt verarbeitet in München, aus recyceltem Kaffeesatz aus lokalen Cafés. Kein Plastik. Kein Abfall. Nur etwas Echtes.\n\nWas enthalten ist:\n— 1 × Sunny Sage Seife (100g)\n— 1 × Calm Seife (100g)\n— 1 × Handgefertigter Holzseifenhalter\n\nDie vollständige Zutatenliste findest du auf den Produktseiten von Sunny Sage und Calm."
+    "adama-bundle": {
+      "name": "Adama Bundle",
+      "description": "Zwei Seifen. Eine Schale. Das ganze Ritual.\n\nDas Adama Bundle vereint unsere beiden handgemachten Kaffee-Peeling-Seifen - Sunny Sage (Orange + Salbei) und Calm (Lavendel) mit einer handgefertigten Holzseifenschale, die sie zwischen den Duschen trocken hält.\n\nBeide Seifen werden hier in München von Hand kalt verseift, hergestellt mit Kaffeesatz, den wir aus lokalen Cafés upcyceln. Vegan. Plastikfrei. Nichts darin, was wir nicht selbst auf unsere Haut geben würden.\n\nFür dich selbst. Oder für jemanden, dem du etwas Echtes schenken möchtest.\n\nWas enthalten ist:\n- 1 × Sunny Sage Seife (100g)\n- 1 × Calm Seife (100g)\n- 1 × Handgefertigte Holzseifenschale\n\nDie vollständige Zutatenliste findest du auf den Produktseiten von Sunny Sage und Calm.\n\nAdama. Stay clean. Stay grounded."
     },
     "sunny-sage": {
       "name": "Sunny Sage",

--- a/messages/en.json
+++ b/messages/en.json
@@ -73,9 +73,9 @@
         "Limonene"
       ]
     },
-    "adama-easter-set": {
-      "name": "Adama Easter Set",
-      "description": "This Easter, give a gift that actually means something.\n\nThe Adama Easter Set brings together two of our handmade soaps — Sunny Sage and Calm — alongside a handcrafted wooden soap tray, made to keep your bar dry and your bathroom beautiful.\n\nEvery soap is cold-processed by hand in Munich, made from recycled coffee grounds sourced from local cafés. No plastic. No waste. Just something real.\n\nWhat's inside:\n— 1 × Sunny Sage soap (100g)\n— 1 × Calm soap (100g)\n— 1 × Handmade wooden soap tray\n\nFor the full ingredients list, visit the individual product pages for Sunny Sage and Calm."
+    "adama-bundle": {
+      "name": "Adama Bundle",
+      "description": "Two bars. One tray. The whole ritual.\n\nThe Adama Bundle pairs both of our handmade coffee-scrub bars - Sunny Sage (orange + sage) and Calm (lavender) with a handcrafted wooden soap tray made to keep them dry between showers.\n\nBoth bars are cold-processed by hand here in Munich, made with coffee grounds we upcycle from local cafés. Vegan. Plastic-free. Nothing in here we wouldn't put on our own skin.\n\nFor yourself. Or for someone you'd give something real to.\n\nWhat's inside:\n- 1 × Sunny Sage soap (100g)\n- 1 × Calm soap (100g)\n- 1 × Handmade wooden soap tray\n\nFor the full ingredient lists, see the Sunny Sage and Calm product pages.\n\nAdama. Stay clean. Stay grounded."
     },
     "sunny-sage": {
       "name": "Sunny Sage",


### PR DESCRIPTION
## Summary
- Reorder the products array so the home-page carousel opens on **Calm + Sunny Sage** instead of Calm + the bundle; the bundle is still in the carousel and appears when the user clicks the arrow.
- Rename **Adama Easter Set → Adama Bundle** (slug `adama-easter-set` → `adama-bundle`) with the new "Two bars. One tray. The whole ritual." description in both EN and DE.
- Update the PayPal button mapping to the new slug (same PayPal button ID).

## Notes
- Old URL `/shop/adama-easter-set` will 404 after merge — no internal links reference it, but any externally shared links will break.
- German copy was translated from the new English description using the existing informal "du" style — worth a quick read before merging.

## Test plan
- [ ] Vercel preview opens with **Calm** and **Sunny Sage** in the carousel
- [ ] Clicking the right arrow reveals **Adama Bundle**
- [ ] `/shop/adama-bundle` loads with the new name and description (EN + DE)
- [ ] PayPal "Add to Cart" button still works on the bundle page

> A Vercel preview deployment will be automatically generated for this PR.
> Please verify the changes at the preview URL before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)